### PR TITLE
Profile Edit Page Debug & Adjustments

### DIFF
--- a/app/views/carriers/registrations/_vehicle_fields.html.erb
+++ b/app/views/carriers/registrations/_vehicle_fields.html.erb
@@ -31,6 +31,7 @@
 
     <%= link_to_remove_association "⤫",
       f,
-      class: "btn btnSmall btnNull btnRemoveNestForm" %>
+      class: "btn btnSmall btnNull btnRemoveNestForm",
+      onclick: "onRemove();" %>
   </div>
 </div>

--- a/app/views/carriers/registrations/edit.html.erb
+++ b/app/views/carriers/registrations/edit.html.erb
@@ -1,7 +1,7 @@
 <section id="carrier__edit" class="container-fluid carrier slimSmall">
   <div>
     <h2>運送アカウント情報</h2>
-    <% if params["action"] == "edit" %>
+    <% if params["action"] == "edit" || params["action"] == "update" %>
       <p class="inputBank hidden"><%= @carrier.to_json %></p>
       <p class="inputBankVehicle hidden"><%= @carrier.vehicles.to_json %></p>
       <%= render partial: 'restoreInputs', formats: :js %>
@@ -35,9 +35,12 @@
 
 
 <script type="text/javascript" src="//code.jquery.com/jquery-2.1.0.min.js"></script>
+<%= render partial: 'shared/scrollTo', formats: :js %>  <!-- onClick of prefecture input scroll so it is within view -->
+<%= render partial: 'shared/carrier_strengths', formats: :js %>  <!-- Make sure Carrier specialties grading is doesn't have duplicates -->
 <%= render partial: 'shared/jquery.jpostal', formats: :js %>  <!-- JS for automated address input upon postal code input -->
 <%= render partial: 'shared/jpostal.carrierActivator', formats: :js %>
 <%= render partial: 'shared/multiple-select', formats: :js %>  <!-- JS for making <select> with <optgroup> into a dropdown with grouped checkboxes -->
 <%= render partial: 'shared/multiple-selectActivator', formats: :js %>
 <%= render partial: 'shared/carrier_favorite_products', formats: :js %>  <!-- JS to ensure no more than 3 products can be checked -->
 <%= render partial: 'shared/wordCounter', formats: :js %>  <!-- Word counter for strength and description input -->
+<%= render partial: 'shared/hideVehicleDel', formats: :js %>  <!-- Ensure one vehicle by hiding the delete button -->

--- a/app/views/shared/_hideVehicleDel.js.erb
+++ b/app/views/shared/_hideVehicleDel.js.erb
@@ -1,0 +1,24 @@
+<% content_for(:after_js) do %>
+  <%= javascript_tag do %>
+
+    const targetArea = document.querySelector("#carrier__vehicles__container");
+    const addBtn = document.querySelector(".btnAddNestForm");
+    let removeBtns, currentFields;
+
+    addBtn.addEventListener('click', onAdd);
+
+    function onAdd() {
+      currentFields = targetArea.querySelectorAll("div.nested-fields:not([style*=none])");
+      removeBtns = targetArea.querySelectorAll(".btnRemoveNestForm");
+      if(currentFields.length + 1 > 1) removeBtns.forEach(btn => btn.classList.remove('hidden'));
+    }
+
+    // Due the target being a dynamic added element, I used 'onclick: onRemove();' in '_vehicle_fields.html.erb'
+    function onRemove() {
+      currentFields = targetArea.querySelectorAll("div.nested-fields:not([style*=none])");
+      removeBtns = targetArea.querySelectorAll(".btnRemoveNestForm");
+      if(currentFields.length - 1 < 2) removeBtns.forEach(btn => btn.classList.add('hidden'));
+    }
+
+  <% end %>
+<% end %>

--- a/app/views/shared/_wordCounter.js.erb
+++ b/app/views/shared/_wordCounter.js.erb
@@ -3,12 +3,26 @@
     document.addEventListener("DOMContentLoaded", () => {
 
       const inputs = document.querySelectorAll("[data-wordcounter='true']");
-      inputs.forEach(input => input.addEventListener('input', handleInput))
+      inputs.forEach(input => updateCount(input));
+      inputs.forEach(input => input.addEventListener('input', handleInput));
 
-      function handleInput () {
+      function updateCount(input) {
+        if(input.value.length > 0) {
+          const maxLength = input.attributes.maxLength.value;
+          const currentLength = input.value.length;
+          const counter = document.querySelector(`span.${input.id}`);
+          textColor(counter, maxLength, currentLength);
+        }
+      }
+
+      function handleInput() {
         const maxLength = this.attributes.maxLength.value;
         const currentLength = this.value.length;
         const counter = document.querySelector(`span.${this.id}`);
+        textColor(counter, maxLength, currentLength);
+      }
+
+      function textColor(counter, maxLength, currentLength) {
         if(maxLength - currentLength < maxLength / 4) {
           counter.style.color = '#EE5F5B';
         } else {


### PR DESCRIPTION
- [DONE] Specialties not showing duplicated error message.
  => Now shows error message if duplicates selected.

- [DONE] Prefecture checks not reflected after region checked.
  => Does not toggle, it just checks. So no uncheck functionality by default.

- [DONE] Edit profile prefecture placeholder
  => Probably due to 'inputBank' being unavailable when params['action'] == 'update'
  => 'inputBank' is now availabler after error-submit on edit-profile. Should fix?

- [DONE] WordCounter on edit page is reset.
  => Adjusted code to count if there is already text inside.

- [DONE] Edit profile 1-vehicle X button
  => Made new JS to remove delete button when there is only one vehicle field.