### PR TITLE
Add destroy user function

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,7 @@
 continue
+resource_name
+resource
+continue
 @all_carriers_two_conditions.count
 @all_carriers_two_conditions
 continue
@@ -251,6 +254,3 @@ params
 exit
 params
 continue
-params
-exit
-params

--- a/app/controllers/carriers/registrations_controller.rb
+++ b/app/controllers/carriers/registrations_controller.rb
@@ -53,6 +53,15 @@ class Carriers::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
+  def destroy
+    # userモデルのleaveメソッド
+    resource.leave
+    Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+    redirect_to root_path
+    set_flash_message(:notice, :destroyed)
+  end
+
+
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign
   # in to be expired now. This is useful if the user wants to

--- a/app/models/carrier.rb
+++ b/app/models/carrier.rb
@@ -34,4 +34,28 @@ class Carrier < ApplicationRecord
   FAVORITE_PRODUCTS =
     %w(精密機器 重量物 展示会用品 建築資材 印刷物 家具 楽器 衣料品 農産物 食料品
        美術品 仏壇・仏具 洋紙 遊技機)
+
+  def leave
+    #leave_atに退会時刻を追記
+    update_attribute(:leave_at, Time.current)
+
+    # また、userのメールアドレスの頭にleave_atを追加する。
+    # メールアドレスを変更すると原則確認メールが送信されるため、
+    # 送信をスキップすることを宣言した上でupdateする。
+    new_email = self.leave_at.to_i.to_s + '_' + self.email.to_s
+
+    # devise :confirmable した モデルには skip_confirmation! skip_reconfirmation!
+    # というメソッドが追加されるので下記のコードを追加
+    # self.skip_reconfirmation!
+
+    update_attribute(:email, new_email)
+
+    # また、social_profilesが存在する場合はuidの頭にもleave_atを追加する
+    # fb,twitter両方連携されている場合があるため、each doしている。
+    # social_profiles = self.social_profiles
+    # social_profiles.each do |sp|
+    #   new_uid = self.leave_at.to_i.to_s + '_' + sp.uid.to_s
+    #   sp.update_attribute(:uid, new_uid)
+    # end
+  end
 end

--- a/config/initializers/rack_rewrite.rb
+++ b/config/initializers/rack_rewrite.rb
@@ -1,7 +1,7 @@
 if ENV['RACK_ENV'] == 'production'
   Transroad::Application.config.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
     r301 %r{.*}, 'https://transroad.jp$&', :if => Proc.new {|rack_env|
-      rack_env['SERVER_NAME'] == 'www.transroad.jp.herokudns.com'
+      rack_env['SERVER_NAME'] == 'www.transroad.jp'
     }
   end
 end

--- a/config/initializers/rack_rewrite.rb
+++ b/config/initializers/rack_rewrite.rb
@@ -1,7 +1,7 @@
-if ENV['RACK_ENV'] == 'production'
-  Transroad::Application.config.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
-    r301 %r{.*}, 'https://transroad.jp$&', :if => Proc.new {|rack_env|
-      rack_env['SERVER_NAME'] == 'www.transroad.jp'
-    }
-  end
-end
+# if ENV['RACK_ENV'] == 'production'
+#   Transroad::Application.config.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
+#     r301 %r{.*}, 'https://transroad.jp$&', :if => Proc.new {|rack_env|
+#       rack_env['SERVER_NAME'] == 'www.transroad.jp'
+#     }
+#   end
+# end

--- a/config/initializers/rack_rewrite.rb
+++ b/config/initializers/rack_rewrite.rb
@@ -1,5 +1,5 @@
 if ENV['RACK_ENV'] == 'production'
-  MyAppName::Application.config.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
+  Transroad::Application.config.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
     r301 %r{.*}, 'https://transroad.jp$&', :if => Proc.new {|rack_env|
       rack_env['SERVER_NAME'] == 'www.transroad.jp.herokudns.com'
     }

--- a/config/initializers/rack_rewrite.rb
+++ b/config/initializers/rack_rewrite.rb
@@ -1,7 +1,7 @@
 if ENV['RACK_ENV'] == 'production'
   MyAppName::Application.config.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
     r301 %r{.*}, 'https://transroad.jp$&', :if => Proc.new {|rack_env|
-      rack_env['SERVER_NAME'] == 'www.transroad.jp'
+      rack_env['SERVER_NAME'] == 'www.transroad.jp.herokudns.com'
     }
   end
 end

--- a/db/migrate/20180505014451_add_leave_at_to_carriers.rb
+++ b/db/migrate/20180505014451_add_leave_at_to_carriers.rb
@@ -1,0 +1,5 @@
+class AddLeaveAtToCarriers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :carriers, :leave_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180425101129) do
+ActiveRecord::Schema.define(version: 20180505014451) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20180425101129) do
     t.string "specialties", default: [], array: true
     t.string "strength_1"
     t.string "strength_2"
+    t.datetime "leave_at"
     t.index ["email"], name: "index_carriers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_carriers_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
- Carriers can do 解約 with leave function.
- The email will be changed and the Carrier won't be able to log in with current email again.
- Only the admin can delete the Carrier account permanently.